### PR TITLE
fixed translation error

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 You can use this script to make sure your user has enough energy on his device.
 
-E.g. if he is writing an article (which should be anyways saved to localStorage) the page can notify the user about his low accu.
+E.g. if he is writing an article (which should be anyways saved to localStorage) the page can notify the user about his low battery.
 
 *Note*:
 This works since Chrome 38


### PR DESCRIPTION
"Akku" (German) -> "battery" (English)
